### PR TITLE
feat: Add ability to delete all existing comments

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ interface CliOptions {
   mode: string;
   tui?: boolean;
   pr?: string;
+  clean?: boolean;
 }
 
 const program = new Command();
@@ -51,6 +52,7 @@ program
   .option('--mode <mode>', 'diff mode (side-by-side or inline)', 'side-by-side')
   .option('--tui', 'use terminal UI instead of web interface')
   .option('--pr <url>', 'GitHub PR URL to review (e.g., https://github.com/owner/repo/pull/123)')
+  .option('--clean', 'start with a clean slate by clearing all existing comments')
   .action(async (commitish: string, compareWith: string | undefined, options: CliOptions) => {
     try {
       // Determine target and base commitish
@@ -130,10 +132,15 @@ program
         host: options.host,
         openBrowser: options.open,
         mode: options.mode,
+        clearComments: options.clean,
       });
 
       console.log(`\n🚀 difit server started on ${url}`);
       console.log(`📋 Reviewing: ${targetCommitish}`);
+
+      if (options.clean) {
+        console.log('🧹 Starting with a clean slate - all existing comments will be cleared');
+      }
 
       if (isEmpty) {
         console.log(

--- a/src/client/App.test.tsx
+++ b/src/client/App.test.tsx
@@ -1,6 +1,222 @@
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
 
+import { mockFetch } from '../../vitest.setup';
 import type { DiffResponse } from '../types/diff';
+
+import App from './App';
+
+// Mock the useLocalComments hook
+vi.mock('./hooks/useLocalComments', () => ({
+  useLocalComments: vi.fn(() => ({
+    comments: mockComments,
+    addComment: vi.fn(),
+    removeComment: vi.fn(),
+    updateComment: vi.fn(),
+    clearAllComments: mockClearAllComments,
+    generatePrompt: vi.fn(),
+    generateAllCommentsPrompt: vi.fn(),
+  })),
+}));
+
+// Mock navigator.sendBeacon
+Object.defineProperty(navigator, 'sendBeacon', {
+  writable: true,
+  value: vi.fn(),
+});
+
+// Mock window.confirm
+const mockConfirm = vi.fn();
+Object.defineProperty(window, 'confirm', {
+  writable: true,
+  value: mockConfirm,
+});
+
+// Mock EventSource
+const mockEventSource = {
+  onopen: vi.fn(),
+  onerror: vi.fn(),
+  close: vi.fn(),
+};
+Object.defineProperty(window, 'EventSource', {
+  writable: true,
+  value: vi.fn(() => mockEventSource),
+});
+
+let mockComments: any[] = [];
+const mockClearAllComments = vi.fn();
+
+const mockDiffResponse: DiffResponse = {
+  commit: 'abc123',
+  files: [
+    {
+      path: 'test.ts',
+      status: 'modified',
+      additions: 5,
+      deletions: 2,
+      chunks: [],
+    },
+  ],
+  ignoreWhitespace: false,
+  isEmpty: false,
+  mode: 'side-by-side',
+};
+
+describe('App Component - Clear Comments Functionality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComments = [];
+    mockConfirm.mockReturnValue(false);
+    mockFetch(mockDiffResponse);
+  });
+
+  describe('Delete All Comments Button', () => {
+    it('should not show delete button when no comments exist', async () => {
+      mockComments = [];
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Delete All Comments')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show delete button when comments exist', async () => {
+      mockComments = [
+        {
+          id: 'test-1',
+          file: 'test.ts',
+          line: 10,
+          body: 'Test comment',
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      ];
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete All Comments')).toBeInTheDocument();
+      });
+    });
+
+    it('should show confirmation dialog when delete button is clicked', async () => {
+      mockComments = [
+        { id: '1', file: 'test.ts', line: 10, body: 'Comment 1', timestamp: '2024-01-01' },
+        { id: '2', file: 'test.ts', line: 20, body: 'Comment 2', timestamp: '2024-01-01' },
+      ];
+
+      render(<App />);
+
+      await waitFor(() => {
+        const deleteButton = screen.getByText('Delete All Comments');
+        fireEvent.click(deleteButton);
+      });
+
+      expect(mockConfirm).toHaveBeenCalledWith('Are you sure you want to delete all 2 comments?');
+    });
+
+    it('should call clearAllComments when user confirms deletion', async () => {
+      mockComments = [
+        { id: '1', file: 'test.ts', line: 10, body: 'Comment 1', timestamp: '2024-01-01' },
+      ];
+      mockConfirm.mockReturnValue(true);
+
+      render(<App />);
+
+      await waitFor(() => {
+        const deleteButton = screen.getByText('Delete All Comments');
+        fireEvent.click(deleteButton);
+      });
+
+      expect(mockClearAllComments).toHaveBeenCalled();
+    });
+
+    it('should not call clearAllComments when user cancels deletion', async () => {
+      mockComments = [
+        { id: '1', file: 'test.ts', line: 10, body: 'Comment 1', timestamp: '2024-01-01' },
+      ];
+      mockConfirm.mockReturnValue(false);
+
+      render(<App />);
+
+      await waitFor(() => {
+        const deleteButton = screen.getByText('Delete All Comments');
+        fireEvent.click(deleteButton);
+      });
+
+      expect(mockClearAllComments).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Clean flag on Startup', () => {
+    it('should clear existing comments when clearComments flag is true in response', async () => {
+      const responseWithClearFlag: DiffResponse = {
+        ...mockDiffResponse,
+        clearComments: true,
+      };
+
+      mockFetch(responseWithClearFlag);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(mockClearAllComments).toHaveBeenCalled();
+      });
+    });
+
+    it('should not clear comments when clearComments flag is false', async () => {
+      const responseWithoutClearFlag: DiffResponse = {
+        ...mockDiffResponse,
+        clearComments: false,
+      };
+
+      mockFetch(responseWithoutClearFlag);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(mockClearAllComments).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should not clear comments when clearComments flag is undefined', async () => {
+      const responseWithoutFlag: DiffResponse = {
+        ...mockDiffResponse,
+        // clearComments is undefined
+      };
+
+      mockFetch(responseWithoutFlag);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(mockClearAllComments).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should log message when clearing comments via CLI flag', async () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const responseWithClearFlag: DiffResponse = {
+        ...mockDiffResponse,
+        clearComments: true,
+      };
+
+      mockFetch(responseWithClearFlag);
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          '✅ All existing comments cleared as requested via --clean flag'
+        );
+      });
+
+      consoleLogSpy.mockRestore();
+    });
+  });
+});
 
 describe('Client mode handling logic', () => {
   it('validates DiffResponse interface includes mode', () => {
@@ -58,5 +274,26 @@ describe('Client mode handling logic', () => {
     expect(setModeFromResponse(responseWithInline)).toBe('inline');
     expect(setModeFromResponse(responseWithSideBySide)).toBe('side-by-side');
     expect(setModeFromResponse(responseWithoutMode)).toBe('side-by-side');
+  });
+});
+
+describe('DiffResponse clearComments property', () => {
+  it('should accept clearComments as boolean property', () => {
+    const responseWithClearComments: DiffResponse = {
+      commit: 'abc123',
+      files: [],
+      clearComments: true,
+    };
+
+    expect(responseWithClearComments.clearComments).toBe(true);
+  });
+
+  it('should allow clearComments to be optional', () => {
+    const responseWithoutClearComments: DiffResponse = {
+      commit: 'abc123',
+      files: [],
+    };
+
+    expect(responseWithoutClearComments.clearComments).toBeUndefined();
   });
 });

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,13 @@
-import { Columns, AlignLeft, Copy, Settings, PanelLeftClose, PanelLeft } from 'lucide-react';
-import { useState, useEffect, useCallback } from 'react';
+import {
+  Columns,
+  AlignLeft,
+  Copy,
+  Settings,
+  PanelLeftClose,
+  PanelLeft,
+  Trash2,
+} from 'lucide-react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { type DiffResponse, type LineNumber } from '../types/diff';
 
@@ -32,6 +40,7 @@ function App() {
     addComment,
     removeComment,
     updateComment,
+    clearAllComments,
     generatePrompt,
     generateAllCommentsPrompt,
   } = useLocalComments(diffData?.commit);
@@ -105,6 +114,16 @@ function App() {
   useEffect(() => {
     void fetchDiffData();
   }, [fetchDiffData]);
+
+  // Clear comments on initial load if requested via CLI flag
+  const hasCleanedRef = useRef(false);
+  useEffect(() => {
+    if (diffData?.clearComments && !hasCleanedRef.current) {
+      hasCleanedRef.current = true;
+      clearAllComments();
+      console.log('✅ All existing comments cleared as requested via --clean flag');
+    }
+  }, [diffData?.clearComments, clearAllComments]);
 
   // Send comments to server before page unload
   useEffect(() => {
@@ -292,27 +311,45 @@ function App() {
           </div>
           <div className="flex items-center gap-4 text-sm text-github-text-secondary">
             {comments.length > 0 && (
-              <button
-                onClick={handleCopyAllComments}
-                className="text-xs px-3 py-1.5 rounded transition-all whitespace-nowrap flex items-center gap-1.5"
-                style={{
-                  backgroundColor: 'var(--color-yellow-btn-bg)',
-                  color: 'var(--color-yellow-btn-text)',
-                  border: '1px solid var(--color-yellow-btn-border)',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--color-yellow-btn-hover-bg)';
-                  e.currentTarget.style.borderColor = 'var(--color-yellow-btn-hover-border)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--color-yellow-btn-bg)';
-                  e.currentTarget.style.borderColor = 'var(--color-yellow-btn-border)';
-                }}
-                title={`Copy all ${comments.length} comments to AI coding agent`}
-              >
-                <Copy size={12} />
-                {isCopiedAll ? 'Copied All!' : `Copy All Prompt (${comments.length})`}
-              </button>
+              <>
+                <button
+                  onClick={handleCopyAllComments}
+                  className="text-xs px-3 py-1.5 rounded transition-all whitespace-nowrap flex items-center gap-1.5"
+                  style={{
+                    backgroundColor: 'var(--color-yellow-btn-bg)',
+                    color: 'var(--color-yellow-btn-text)',
+                    border: '1px solid var(--color-yellow-btn-border)',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--color-yellow-btn-hover-bg)';
+                    e.currentTarget.style.borderColor = 'var(--color-yellow-btn-hover-border)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--color-yellow-btn-bg)';
+                    e.currentTarget.style.borderColor = 'var(--color-yellow-btn-border)';
+                  }}
+                  title={`Copy all ${comments.length} comments to AI coding agent`}
+                >
+                  <Copy size={12} />
+                  {isCopiedAll ? 'Copied All!' : `Copy All Prompt (${comments.length})`}
+                </button>
+                <button
+                  onClick={() => {
+                    if (
+                      window.confirm(
+                        `Are you sure you want to delete all ${comments.length} comments?`
+                      )
+                    ) {
+                      clearAllComments();
+                    }
+                  }}
+                  className="text-xs px-3 py-1.5 rounded transition-all whitespace-nowrap flex items-center gap-1.5 text-github-danger hover:text-github-danger-hover bg-github-bg-tertiary hover:bg-github-danger-subtle border border-github-border hover:border-github-danger"
+                  title={`Delete all ${comments.length} comments`}
+                >
+                  <Trash2 size={12} />
+                  Delete All Comments
+                </button>
+              </>
             )}
             <div className="flex flex-col gap-1 items-center">
               <div className="text-xs">

--- a/src/client/hooks/useLocalComments.test.ts
+++ b/src/client/hooks/useLocalComments.test.ts
@@ -1,0 +1,223 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { useLocalComments } from './useLocalComments';
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('useLocalComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  it('should initialize with empty comments when localStorage is empty', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    expect(result.current.comments).toEqual([]);
+  });
+
+  it('should load comments from localStorage on mount', () => {
+    const savedComments = [
+      {
+        id: 'test-id-1',
+        file: 'test.ts',
+        line: 10,
+        body: 'Test comment',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+
+    localStorageMock.getItem.mockReturnValue(JSON.stringify(savedComments));
+
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    expect(localStorageMock.getItem).toHaveBeenCalledWith('difit-comments-test-commit');
+    expect(result.current.comments).toEqual(savedComments);
+  });
+
+  it('should add a comment correctly', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    act(() => {
+      result.current.addComment('test.ts', 10, 'New comment', 'const x = 1;');
+    });
+
+    expect(result.current.comments).toHaveLength(1);
+    expect(result.current.comments[0]).toMatchObject({
+      file: 'test.ts',
+      line: 10,
+      body: 'New comment',
+      codeContent: 'const x = 1;',
+    });
+    expect(result.current.comments[0]?.id).toContain('test.ts:10:');
+  });
+
+  it('should remove a comment by id', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    // Add two comments
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Comment 1');
+      result.current.addComment('test.ts', 20, 'Comment 2');
+    });
+
+    const commentId = result.current.comments[0]!.id;
+
+    act(() => {
+      result.current.removeComment(commentId);
+    });
+
+    expect(result.current.comments).toHaveLength(1);
+    expect(result.current.comments[0]?.body).toBe('Comment 2');
+  });
+
+  it('should update a comment body', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Original comment');
+    });
+
+    const commentId = result.current.comments[0]!.id;
+
+    act(() => {
+      result.current.updateComment(commentId, 'Updated comment');
+    });
+
+    expect(result.current.comments[0]?.body).toBe('Updated comment');
+  });
+
+  it('should clear all comments and remove from localStorage', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    // Add multiple comments
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Comment 1');
+      result.current.addComment('test.ts', 20, 'Comment 2');
+      result.current.addComment('other.ts', 5, 'Comment 3');
+    });
+
+    expect(result.current.comments).toHaveLength(3);
+
+    act(() => {
+      result.current.clearAllComments();
+    });
+
+    expect(result.current.comments).toEqual([]);
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('difit-comments-test-commit');
+  });
+
+  it('should generate prompt for a single comment', () => {
+    const { result } = renderHook(() => useLocalComments());
+
+    const comment = {
+      id: 'test-id',
+      file: 'test.ts',
+      line: 10,
+      body: 'Fix this bug',
+      timestamp: '2024-01-01T00:00:00.000Z',
+    };
+
+    const prompt = result.current.generatePrompt(comment);
+
+    expect(prompt).toBe('test.ts:L10\nFix this bug');
+  });
+
+  it('should generate prompt for a comment with line range', () => {
+    const { result } = renderHook(() => useLocalComments());
+
+    const comment = {
+      id: 'test-id',
+      file: 'test.ts',
+      line: [10, 20] as [number, number],
+      body: 'Refactor this function',
+      timestamp: '2024-01-01T00:00:00.000Z',
+    };
+
+    const prompt = result.current.generatePrompt(comment);
+
+    expect(prompt).toBe('test.ts:L10-L20\nRefactor this function');
+  });
+
+  it('should generate prompt for all comments', () => {
+    const { result } = renderHook(() => useLocalComments());
+
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Comment 1');
+      result.current.addComment('test.ts', [20, 25] as [number, number], 'Comment 2');
+      result.current.addComment('other.ts', 5, 'Comment 3');
+    });
+
+    const allPrompts = result.current.generateAllCommentsPrompt();
+
+    expect(allPrompts).toContain('test.ts:L10\nComment 1');
+    expect(allPrompts).toContain('test.ts:L20-L25\nComment 2');
+    expect(allPrompts).toContain('other.ts:L5\nComment 3');
+    expect(allPrompts).toContain('=====');
+  });
+
+  it('should return appropriate message when no comments exist', () => {
+    const { result } = renderHook(() => useLocalComments());
+
+    const allPrompts = result.current.generateAllCommentsPrompt();
+
+    expect(allPrompts).toBe('No comments available.');
+  });
+
+  it('should save comments to localStorage whenever they change', () => {
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Comment 1');
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'difit-comments-test-commit',
+      expect.stringContaining('Comment 1')
+    );
+
+    act(() => {
+      result.current.clearAllComments();
+    });
+
+    // Should set empty array before removing
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('difit-comments-test-commit', '[]');
+  });
+
+  it('should use default storage key when no commit hash provided', () => {
+    const { result } = renderHook(() => useLocalComments());
+
+    act(() => {
+      result.current.addComment('test.ts', 10, 'Comment');
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('difit-comments', expect.any(String));
+  });
+
+  it('should handle corrupted localStorage data gracefully', () => {
+    localStorageMock.getItem.mockReturnValue('invalid json');
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useLocalComments('test-commit'));
+
+    expect(result.current.comments).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to parse saved comments:',
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -499,4 +499,54 @@ describe('Server Integration Tests', () => {
       }
     });
   });
+
+  describe('Clear Comments functionality', () => {
+    it('includes clearComments flag in diff response when provided', async () => {
+      const { port, server } = await startServer({
+        targetCommitish: 'HEAD',
+        baseCommitish: 'HEAD^',
+        clearComments: true,
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://localhost:${port}/api/diff`);
+      const data = (await response.json()) as any;
+
+      expect(response.ok).toBe(true);
+      expect(data.clearComments).toBe(true);
+    });
+
+    it('does not include clearComments flag when not provided', async () => {
+      const { port, server } = await startServer({
+        targetCommitish: 'HEAD',
+        baseCommitish: 'HEAD^',
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://localhost:${port}/api/diff`);
+      const data = (await response.json()) as any;
+
+      expect(response.ok).toBe(true);
+      expect(data.clearComments).toBeUndefined();
+    });
+
+    it('preserves clearComments flag across diff requests', async () => {
+      const { port, server } = await startServer({
+        targetCommitish: 'HEAD',
+        baseCommitish: 'HEAD^',
+        clearComments: true,
+      });
+      servers.push(server);
+
+      // First request
+      const response1 = await fetch(`http://localhost:${port}/api/diff`);
+      const data1 = (await response1.json()) as any;
+      expect(data1.clearComments).toBe(true);
+
+      // Second request with different ignoreWhitespace
+      const response2 = await fetch(`http://localhost:${port}/api/diff?ignoreWhitespace=true`);
+      const data2 = (await response2.json()) as any;
+      expect(data2.clearComments).toBe(true);
+    });
+  });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,7 @@ interface ServerOptions {
   openBrowser?: boolean;
   mode?: string;
   ignoreWhitespace?: boolean;
+  clearComments?: boolean;
 }
 
 export async function startServer(
@@ -72,6 +73,7 @@ export async function startServer(
       mode: diffMode,
       baseCommitish: options.baseCommitish,
       targetCommitish: options.targetCommitish,
+      clearComments: options.clearComments,
     });
   });
 

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -43,6 +43,7 @@ export interface DiffResponse {
   mode?: string;
   baseCommitish?: string;
   targetCommitish?: string;
+  clearComments?: boolean;
 }
 
 export type LineNumber = number | [number, number];


### PR DESCRIPTION
Thank you for creating difit\! It's an incredibly useful tool for code reviews. This PR adds functionality to help manage comments across multiple review sessions.

### Problem

When using difit for multiple review sessions:
1. Comments from previous sessions remain visible even after code changes
2. Comments on lines that no longer exist in the diff cannot be deleted through the UI
3. There's no way to start a fresh review session without old comments

### Solution

This PR introduces two ways to delete all existing comments:

#### 1. UI Button - "Delete All Comments"
- Added a red button next to "Copy All Comments" button
- Shows confirmation dialog before deletion
- Allows users to clear all comments during a review session

#### 2. CLI Flag - `--clean`
- Start difit with a clean slate by clearing all existing comments on startup
- Usage: `difit --clean`
- Only clears comments once on initial load (new comments added during the session are not affected)

### Implementation Details

- Modified `useLocalComments` hook to expose the existing `clearAllComments` function
- Added confirmation dialog using `window.confirm()` for safety
- Used `useRef` to ensure CLI flag only triggers cleanup once
- Added comprehensive tests for both UI and CLI functionality

### Testing

- Added tests for `useLocalComments` hook
- Added tests for App component (UI button functionality)
- Added tests for CLI flag functionality
- All existing tests pass

### Breaking Changes

None. This is a purely additive feature.