### PR TITLE
  feat: add C# syntax highlighting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ difit supports syntax highlighting for multiple programming languages with dynam
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish` files
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, C#
-- **Systems Languages**: C, C++, Rust, Go
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala
+- **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Others**: Python, YAML, Solidity, Vim script
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ difit supports syntax highlighting for multiple programming languages with dynam
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish` files
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, C#
 - **Systems Languages**: C, C++, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Others**: Python, YAML, Solidity, Vim script

--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -77,6 +77,7 @@ function detectLanguage(filename: string): string {
     sol: 'solidity',
     vim: 'vim',
     dart: 'dart',
+    cs: 'csharp',
   };
 
   return extensionMap[ext || ''] || 'text';

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -27,6 +27,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       solidity: () => import('prismjs/components/prism-solidity.js'),
       vim: () => import('prismjs/components/prism-vim.js'),
       dart: () => import('prismjs/components/prism-dart.js'),
+      csharp: () => import('prismjs/components/prism-csharp.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
  ## Summary
  Add comprehensive C# syntax highlighting support to difit with proper language categorization.

  ## Changes
  - Add `.cs` file extension mapping to `csharp` language in PrismSyntaxHighlighter.tsx
  - Add dynamic loading for `prism-csharp.js` component in languageLoader.ts
  - Update README.md to include C# in Systems Languages section (positioned after C++)

  ## Technical Details
  - Follows existing language addition patterns for consistency
  - Uses PrismJS standard `csharp` language identifier
  - Categorizes C# as a Systems Language alongside C, C++, Rust, and Go
  - Maintains dynamic loading performance optimization

  ## Test Plan
  - [x ] Verify C# files (.cs) are properly syntax highlighted
  - [x] Confirm dynamic loading works without errors
  - [x ] Check language detection from file extensions