### PR TITLE
feat: Add support for @ symbol as Git HEAD alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npx difit feature  # Latest commit on feature branch
 
 ```bash
 npx difit HEAD main      # Compare HEAD with main branch
+npx difit @ main         # Compare HEAD with main branch (@ is alias for HEAD)
+npx difit @^ @~3         # Compare previous commit with 3 commits ago
 npx difit feature main   # Compare branches
 npx difit . origin/main  # Compare working directory with remote main
 ```

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -33,6 +33,16 @@ describe('CLI Utils', () => {
       expect(validateCommitish('HEAD~2^1')).toBe(true);
     });
 
+    it('should validate @ references (Git alias for HEAD)', () => {
+      expect(validateCommitish('@')).toBe(true);
+      expect(validateCommitish('@~1')).toBe(true);
+      expect(validateCommitish('@~10')).toBe(true);
+      expect(validateCommitish('@^')).toBe(true);
+      expect(validateCommitish('@^1')).toBe(true);
+      expect(validateCommitish('@^2')).toBe(true);
+      expect(validateCommitish('@~2^1')).toBe(true);
+    });
+
     it('should validate branch names', () => {
       // Valid branch names according to git rules
       expect(validateCommitish('main')).toBe(true);
@@ -65,7 +75,7 @@ describe('CLI Utils', () => {
       // Invalid branch names according to git rules
       expect(validateCommitish('-feature')).toBe(false); // cannot start with dash
       expect(validateCommitish('feature.')).toBe(false); // cannot end with dot
-      expect(validateCommitish('@')).toBe(false); // cannot be just @
+      expect(validateCommitish('@')).toBe(true); // @ is a valid Git alias for HEAD
       expect(validateCommitish('feature..test')).toBe(false); // no consecutive dots
       expect(validateCommitish('feature@{upstream}')).toBe(false); // no @{ sequence
       expect(validateCommitish('feature//test')).toBe(false); // no consecutive slashes

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -27,6 +27,7 @@ export function validateCommitish(commitish: string): boolean {
     /^[a-f0-9]{4,40}\^+$/i, // SHA hashes with ^ suffix (parent references)
     /^[a-f0-9]{4,40}~\d+$/i, // SHA hashes with ~N suffix (ancestor references)
     /^HEAD(~\d+|\^\d*)*$/, // HEAD, HEAD~1, HEAD^, HEAD^2, etc.
+    /^@(~\d+|\^\d*)*$/, // @, @~1, @^, @^2, etc. (@ is Git alias for HEAD)
   ];
 
   // Check if it matches any specific patterns first
@@ -42,7 +43,7 @@ function isValidBranchName(name: string): boolean {
   // Git branch name rules
   if (name.startsWith('-')) return false; // Cannot start with dash
   if (name.endsWith('.')) return false; // Cannot end with dot
-  if (name === '@') return false; // Cannot be just @
+  // @ is a valid Git alias for HEAD, so we should allow it
   if (name.includes('..')) return false; // No consecutive dots
   if (name.includes('@{')) return false; // No @{ sequence
   if (name.includes('//')) return false; // No consecutive slashes


### PR DESCRIPTION
## Summary
- Add support for `@` symbol as a Git HEAD alias in difit
- Allow `@` with parent/ancestor references like `@^`, `@~3`, etc.
- Fix validation that was explicitly rejecting `@` despite it being a valid Git reference

## Changes
- Updated `validateCommitish` function to recognize `@` patterns with regex `/^@(~\d+|\^\d*)*$/`
- Removed explicit rejection of `@` from `isValidBranchName` function
- Added comprehensive tests for `@` symbol usage
- Updated README with `@` usage examples

## Test plan
- [x] Added new test cases for `@`, `@^`, `@~1`, `@~2^1` etc.
- [x] All existing tests pass
- [x] Manually verified `git log -1 @` and `git log -1 @~3` work correctly
- [x] Build and lint checks pass

## Why this matters
Git has supported `@` as an alias for HEAD since version 1.8.5. This is a common shorthand that many Git users expect to work. The previous validation was unnecessarily restrictive.

Example usage:
```bash
npx difit @          # Same as npx difit HEAD
npx difit @ main     # Compare HEAD with main
npx difit @^ @~3     # Compare previous commit with 3 commits ago
```

🤖 Generated with [Claude Code](https://claude.ai/code)