### PR TITLE
fix: Fix syntax highlighting disappearing on hover by passing filename prop

### DIFF
--- a/src/client/components/DiffChunk.tsx
+++ b/src/client/components/DiffChunk.tsx
@@ -28,6 +28,7 @@ interface DiffChunkProps {
   fileIndex?: number;
   commentTrigger?: { fileIndex: number; chunkIndex: number; lineIndex: number } | null;
   onCommentTriggerHandled?: () => void;
+  filename?: string;
 }
 
 export function DiffChunk({
@@ -44,6 +45,7 @@ export function DiffChunk({
   fileIndex = 0,
   commentTrigger,
   onCommentTriggerHandled,
+  filename,
 }: DiffChunkProps) {
   const [startLine, setStartLine] = useState<number | null>(null);
   const [endLine, setEndLine] = useState<number | null>(null);
@@ -179,6 +181,7 @@ export function DiffChunk({
         syntaxTheme={syntaxTheme}
         cursor={cursor}
         fileIndex={fileIndex}
+        filename={filename}
         commentTrigger={commentTrigger}
         onCommentTriggerHandled={onCommentTriggerHandled}
       />
@@ -253,6 +256,7 @@ export function DiffChunk({
                     setEndLine(null);
                   }}
                   syntaxTheme={syntaxTheme}
+                  filename={filename}
                 />
 
                 {lineComments.map((comment) => {

--- a/src/client/components/DiffLineRow.tsx
+++ b/src/client/components/DiffLineRow.tsx
@@ -19,6 +19,7 @@ interface DiffLineRowProps {
   onCommentButtonMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onCommentButtonMouseUp: (e: React.MouseEvent<HTMLButtonElement>) => void;
   syntaxTheme?: AppearanceSettings['syntaxTheme'];
+  filename?: string;
 }
 
 const getLineClass = (line: DiffLine) => {
@@ -56,6 +57,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
     onCommentButtonMouseDown,
     onCommentButtonMouseUp,
     syntaxTheme,
+    filename,
   }) => {
     const lineNumber = line.newLineNumber || line.oldLineNumber;
     const showCommentButton = hoveredLine === lineNumber && lineNumber;
@@ -97,6 +99,7 @@ export const DiffLineRow: React.FC<DiffLineRowProps> = React.memo(
               code={line.content}
               className="flex-1 px-3 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
               syntaxTheme={syntaxTheme}
+              filename={filename}
             />
           </div>
         </td>

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -17,7 +17,6 @@ import { isImageFile } from '../utils/imageUtils';
 
 import { DiffChunk } from './DiffChunk';
 import { ImageDiffChunk } from './ImageDiffChunk';
-import { setCurrentFilename } from './PrismSyntaxHighlighter';
 import type { AppearanceSettings } from './SettingsModal';
 
 interface DiffViewerProps {
@@ -64,9 +63,6 @@ export function DiffViewer({
 }: DiffViewerProps) {
   const isCollapsed = reviewedFiles.has(file.path);
   const [isCopied, setIsCopied] = useState(false);
-
-  // Set filename for syntax highlighter immediately
-  setCurrentFilename(file.path);
 
   const getFileIcon = (status: DiffFile['status']) => {
     switch (status) {

--- a/src/client/components/DiffViewer.tsx
+++ b/src/client/components/DiffViewer.tsx
@@ -198,6 +198,7 @@ export function DiffViewer({
                     fileIndex={fileIndex}
                     commentTrigger={commentTrigger?.chunkIndex === index ? commentTrigger : null}
                     onCommentTriggerHandled={onCommentTriggerHandled}
+                    filename={file.path}
                   />
                 </div>
               );

--- a/src/client/components/EnhancedPrismSyntaxHighlighter.tsx
+++ b/src/client/components/EnhancedPrismSyntaxHighlighter.tsx
@@ -88,6 +88,3 @@ export const EnhancedPrismSyntaxHighlighter = React.memo(function EnhancedPrismS
     />
   );
 });
-
-// Re-export setCurrentFilename from PrismSyntaxHighlighter
-export { setCurrentFilename } from './PrismSyntaxHighlighter';

--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -93,12 +93,6 @@ function detectLanguage(filename: string): string {
   return extensionMap[ext || ''] || 'text';
 }
 
-let currentFilename = '';
-
-export function setCurrentFilename(filename: string) {
-  currentFilename = filename;
-}
-
 export const PrismSyntaxHighlighter = React.memo(function PrismSyntaxHighlighter({
   code,
   language,
@@ -109,8 +103,7 @@ export const PrismSyntaxHighlighter = React.memo(function PrismSyntaxHighlighter
   onMouseOver,
   onMouseOut,
 }: PrismSyntaxHighlighterProps) {
-  const detectedLang =
-    language || (filename ? detectLanguage(filename) : detectLanguage(currentFilename));
+  const detectedLang = language || (filename ? detectLanguage(filename) : 'text');
   const { actualLang } = useHighlightedCode(code, detectedLang);
   const theme = getSyntaxTheme(syntaxTheme);
 

--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -13,6 +13,7 @@ export interface PrismSyntaxHighlighterProps {
   language?: string;
   className?: string;
   syntaxTheme?: AppearanceSettings['syntaxTheme'];
+  filename?: string;
   renderToken?: (
     token: Token,
     key: number,
@@ -103,11 +104,13 @@ export const PrismSyntaxHighlighter = React.memo(function PrismSyntaxHighlighter
   language,
   className,
   syntaxTheme = 'vsDark',
+  filename = '',
   renderToken,
   onMouseOver,
   onMouseOut,
 }: PrismSyntaxHighlighterProps) {
-  const detectedLang = language || detectLanguage(currentFilename);
+  const detectedLang =
+    language || (filename ? detectLanguage(filename) : detectLanguage(currentFilename));
   const { actualLang } = useHighlightedCode(code, detectedLang);
   const theme = getSyntaxTheme(syntaxTheme);
 

--- a/src/client/components/SideBySideDiffChunk.tsx
+++ b/src/client/components/SideBySideDiffChunk.tsx
@@ -28,6 +28,7 @@ interface SideBySideDiffChunkProps {
   fileIndex?: number;
   commentTrigger?: { fileIndex: number; chunkIndex: number; lineIndex: number } | null;
   onCommentTriggerHandled?: () => void;
+  filename?: string;
 }
 
 interface SideBySideLine {
@@ -52,6 +53,7 @@ export function SideBySideDiffChunk({
   fileIndex = 0,
   commentTrigger,
   onCommentTriggerHandled,
+  filename,
 }: SideBySideDiffChunkProps) {
   const [startLine, setStartLine] = useState<LineSelection | null>(null);
   const [endLine, setEndLine] = useState<LineSelection | null>(null);
@@ -429,6 +431,7 @@ export function SideBySideDiffChunk({
                           code={sideLine.oldLine.content}
                           className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
                           syntaxTheme={syntaxTheme}
+                          filename={filename}
                         />
                       </div>
                     )}
@@ -495,6 +498,7 @@ export function SideBySideDiffChunk({
                           code={sideLine.newLine.content}
                           className="flex-1 text-github-text-primary whitespace-pre-wrap break-all overflow-wrap-break-word select-text [&_pre]:m-0 [&_pre]:p-0 [&_pre]:!bg-transparent [&_pre]:font-inherit [&_pre]:text-inherit [&_pre]:leading-inherit [&_code]:!bg-transparent [&_code]:font-inherit [&_code]:text-inherit [&_code]:leading-inherit"
                           syntaxTheme={syntaxTheme}
+                          filename={filename}
                         />
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- Fix syntax highlighting that disappears when hovering over files, especially with large diffs
- Pass filename as a prop through the component hierarchy instead of relying on the global currentFilename variable
- Remove the global currentFilename variable completely as it was causing issues

## Problem
When hovering over diff lines, all lines were using the same global `currentFilename` variable for language detection, causing incorrect syntax highlighting. The global variable approach was fundamentally flawed as it couldn't handle multiple files being rendered simultaneously.

## Solution
- Added `filename` prop to `PrismSyntaxHighlighter`, `EnhancedPrismSyntaxHighlighter`, `DiffLineRow`, `DiffChunk`, and `SideBySideDiffChunk`
- Pass the actual filename from `DiffViewer` through the component hierarchy
- Each component now receives the correct filename for proper language detection
- Removed the global `currentFilename` variable and `setCurrentFilename` function entirely

## Why global variables were problematic
Using a global variable for filename was a mistake because:
- Multiple files can be rendered at the same time in the diff view
- React components can re-render in any order
- The global state could be overwritten by any component, causing all components to use the wrong filename

## Test plan
- [x] Tested locally with large diffs
- [x] Verified syntax highlighting remains stable when hovering
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)