### PR TITLE
fix: prevent '.' shortcut when modifier keys are pressed

### DIFF
--- a/src/client/hooks/useKeyboardNavigation.ts
+++ b/src/client/hooks/useKeyboardNavigation.ts
@@ -444,10 +444,21 @@ export function useKeyboardNavigation({
     isHelpOpen,
   ]);
 
-  // Move to center of viewport
-  useHotkeys('.', () => moveToCenterOfViewport(), { ...hotkeyOptions, useKey: true }, [
-    moveToCenterOfViewport,
-  ]);
+  // Move to center of viewport - only if no modifier keys are pressed
+  useHotkeys(
+    '.',
+    (event) => {
+      // Don't execute if any modifier keys are pressed
+      if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) {
+        return;
+      }
+      // Execute for standalone '.' key and prevent other handlers
+      moveToCenterOfViewport();
+      event.preventDefault();
+    },
+    { ...hotkeyOptions, useKey: true, preventDefault: false },
+    [moveToCenterOfViewport]
+  );
 
   // Copy all comments prompt - available in both navigation and comments-list scopes
   useHotkeys(


### PR DESCRIPTION
Modify the '.' key handler to only execute moveToCenterOfViewport when no modifier keys (ctrl, alt, shift, meta) are pressed. This prevents interference with other keyboard shortcuts that use '.' in combination with modifier keys.

`<Ctrl-.>` に設定しているブラウザのショートカットキー､その他拡張のショートカットキーが反応しなくなるので
ctrl, alt, shift, meta キーを押している場合は `moveToCenterOfViewport` が実行されないようにしました｡