### PR TITLE
fix: handle quoted file paths with spaces in diff parsing

### DIFF
--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -122,8 +122,26 @@ export class GitDiffParser {
 
     if (quotedMatch) {
       // Unescape C-style escape sequences in quoted paths
-      oldPath = quotedMatch[1].replace(/\\(.)/g, '$1');
-      newPath = quotedMatch[2].replace(/\\(.)/g, '$1');
+      const unescapePath = (path: string): string => {
+        return path.replace(/\\([\\tnr"])/g, (_match, char) => {
+          switch (char) {
+            case 't':
+              return '\t';
+            case 'n':
+              return '\n';
+            case 'r':
+              return '\r';
+            case '\\':
+              return '\\';
+            case '"':
+              return '"';
+            default:
+              return char as string;
+          }
+        });
+      };
+      oldPath = unescapePath(quotedMatch[1]);
+      newPath = unescapePath(quotedMatch[2]);
     } else if (unquotedMatch) {
       oldPath = unquotedMatch[1];
       newPath = unquotedMatch[2];


### PR DESCRIPTION
## Summary
- Fixed issue where file paths containing spaces or special characters were not properly displayed
- Updated git-diff.ts parser to handle both quoted and unquoted file paths
- Added C-style escape sequence unescaping for quoted paths

## Problem
Files with spaces in their names (e.g., Jinja templates with `{{ package_name }}`) were only showing the last portion of the filename after the last space in the UI.

## Solution
The diff parser now correctly handles Git's C-style quoting for paths containing special characters:
- Detects and parses both quoted (`"a/file name.txt"`) and unquoted (`a/file.txt`) paths
- Properly unescapes C-style escape sequences in quoted paths
- Preserves special characters like `{{ }}` used in Jinja templates

## Test plan
- [x] Tested with files containing spaces in names
- [x] Tested with Jinja template files containing `{{ }}` brackets
- [x] All existing tests pass
- [x] Pre-commit hooks pass

Fixes #83

🤖 Generated with [Claude Code](https://claude.ai/code)