### PR TITLE
fix: normalize git diff paths and keep comment prompts clean

### DIFF
--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -549,6 +549,31 @@ describe('GitDiffParser', () => {
       expect(result.status).toBe('renamed');
     });
 
+    it('prefers header paths over summary paths when they differ', () => {
+      const diffLines = [
+        'diff --git a/a/test.txt b/a/test.txt',
+        'new file mode 100644',
+        'index 0000000..257cc56',
+        '--- /dev/null',
+        '+++ b/a/test.txt',
+        '@@ -0,0 +1 @@',
+        '+content',
+      ];
+
+      const summary = {
+        file: 'a/test.txt',
+        insertions: 1,
+        deletions: 0,
+        binary: false,
+      };
+
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), summary);
+
+      expect(result).toBeDefined();
+      expect(result?.path).toBe('a/test.txt');
+      expect(result?.status).toBe('added');
+    });
+
     it('parses file paths with octal escape sequences correctly', () => {
       const diffLines = [
         'diff --git "a/file\\303\\244.txt" "b/file\\303\\244.txt"',

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -549,6 +549,56 @@ describe('GitDiffParser', () => {
       expect(result.status).toBe('renamed');
     });
 
+    it('handles alternative git diff prefixes for working tree comparisons', () => {
+      const diffLines = [
+        'diff --git c/a/test.txt w/a/test.txt',
+        'index 1234567..8901234 100644',
+        '--- c/a/test.txt',
+        '+++ w/a/test.txt',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+      ];
+
+      const summary = {
+        file: 'a/test.txt',
+        insertions: 1,
+        deletions: 1,
+        binary: false,
+      };
+
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), summary);
+
+      expect(result).toBeDefined();
+      expect(result.path).toBe('a/test.txt');
+      expect(result.oldPath).toBeUndefined();
+      expect(result.status).toBe('modified');
+    });
+
+    it('handles rename metadata with alternative git prefixes', () => {
+      const diffLines = [
+        'diff --git c/old/name.txt w/new/name.txt',
+        'similarity index 100%',
+        'rename from c/old/name.txt',
+        'rename to w/new/name.txt',
+      ];
+
+      const summary = {
+        file: 'new/name.txt',
+        from: 'old/name.txt',
+        insertions: 0,
+        deletions: 0,
+        binary: false,
+      };
+
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), summary);
+
+      expect(result).toBeDefined();
+      expect(result.path).toBe('new/name.txt');
+      expect(result.oldPath).toBe('old/name.txt');
+      expect(result.status).toBe('renamed');
+    });
+
     it('prefers header paths over summary paths when they differ', () => {
       const diffLines = [
         'diff --git a/a/test.txt b/a/test.txt',

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -574,6 +574,32 @@ describe('GitDiffParser', () => {
       expect(result?.status).toBe('added');
     });
 
+    it('does not treat added files as renamed even if summary includes from path', () => {
+      const diffLines = [
+        'diff --git a/test.js b/test.js',
+        'new file mode 100644',
+        'index 0000000..257cc56',
+        '--- /dev/null',
+        '+++ b/test.js',
+        '@@ -0,0 +1 @@',
+        '+console.log("test");',
+      ];
+
+      const summary = {
+        file: 'test.js',
+        from: 'c/test.js',
+        insertions: 1,
+        deletions: 0,
+        binary: false,
+      };
+
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), summary);
+
+      expect(result).toBeDefined();
+      expect(result?.status).toBe('added');
+      expect(result?.oldPath).toBeUndefined();
+    });
+
     it('parses file paths with octal escape sequences correctly', () => {
       const diffLines = [
         'diff --git "a/file\\303\\244.txt" "b/file\\303\\244.txt"',

--- a/src/server/git-diff.test.ts
+++ b/src/server/git-diff.test.ts
@@ -554,7 +554,7 @@ describe('GitDiffParser', () => {
         'diff --git c/a/test.txt w/a/test.txt',
         'index 1234567..8901234 100644',
         '--- c/a/test.txt',
-        '+++ w/a/test.txt',
+        '+++ w/a/test.txt\t',
         '@@ -1 +1 @@',
         '-old',
         '+new',
@@ -579,8 +579,8 @@ describe('GitDiffParser', () => {
       const diffLines = [
         'diff --git c/old/name.txt w/new/name.txt',
         'similarity index 100%',
-        'rename from c/old/name.txt',
-        'rename to w/new/name.txt',
+        'rename from c/old/name.txt\t',
+        'rename to w/new/name.txt\t',
       ];
 
       const summary = {
@@ -597,6 +597,31 @@ describe('GitDiffParser', () => {
       expect(result.path).toBe('new/name.txt');
       expect(result.oldPath).toBe('old/name.txt');
       expect(result.status).toBe('renamed');
+    });
+
+    it('ignores trailing metadata separators in diff path lines', () => {
+      const diffLines = [
+        'diff --git c/foo bar.txt w/foo bar.txt',
+        'index 1234567..8901234 100644',
+        '--- c/foo bar.txt\t',
+        '+++ w/foo bar.txt\t',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+      ];
+
+      const summary = {
+        file: 'foo bar.txt',
+        insertions: 1,
+        deletions: 1,
+        binary: false,
+      };
+
+      const result = (parser as any).parseFileBlock(diffLines.join('\n'), summary);
+
+      expect(result).toBeDefined();
+      expect(result.path).toBe('foo bar.txt');
+      expect(result.status).toBe('modified');
     });
 
     it('prefers header paths over summary paths when they differ', () => {

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -289,7 +289,7 @@ export class GitDiffParser {
     // Common properties for all files
     const baseFile = {
       path,
-      oldPath: oldPath !== newPath ? oldPath : undefined,
+      oldPath: status === 'renamed' && oldPath !== newPath ? oldPath : undefined,
       status,
     };
 

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -124,6 +124,11 @@ export class GitDiffParser {
       }
     }
 
+    const tabIndex = withoutPrefix.indexOf('\t');
+    if (tabIndex !== -1) {
+      withoutPrefix = withoutPrefix.slice(0, tabIndex);
+    }
+
     if (withoutPrefix === '/dev/null') {
       return undefined;
     }

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -4,6 +4,7 @@ import {
   type DiffResult,
   type DiffResultTextFile,
   type DiffResultBinaryFile,
+  type DiffResultNameStatusFile,
 } from 'simple-git';
 
 import { validateDiffArguments, shortHash, createCommitRangeString } from '../cli/utils.js';
@@ -106,18 +107,166 @@ export class GitDiffParser {
     return files;
   }
 
+  private decodeGitPath(rawPath: string | undefined): string | undefined {
+    if (typeof rawPath !== 'string') {
+      return undefined;
+    }
+
+    const trimmed =
+      rawPath.startsWith('"') && rawPath.endsWith('"') ? rawPath.slice(1, -1) : rawPath;
+    const withoutPrefix = trimmed.replace(/^[ab]\//, '');
+
+    if (withoutPrefix === '/dev/null') {
+      return undefined;
+    }
+
+    const bytes: number[] = [];
+    const escapeMap: Record<string, number> = {
+      t: 0x09,
+      n: 0x0a,
+      r: 0x0d,
+      b: 0x08,
+      f: 0x0c,
+      v: 0x0b,
+      a: 0x07,
+      '\\': 0x5c,
+      '"': 0x22,
+      ' ': 0x20,
+    };
+
+    for (let i = 0; i < withoutPrefix.length; i++) {
+      const char = withoutPrefix[i];
+
+      if (char === '\\' && i + 1 < withoutPrefix.length) {
+        const next = withoutPrefix[i + 1];
+
+        if (/[0-7]/.test(next)) {
+          let octal = next;
+          let read = 1;
+
+          while (read < 3 && i + 1 + read < withoutPrefix.length) {
+            const candidate = withoutPrefix[i + 1 + read];
+            if (!/[0-7]/.test(candidate)) {
+              break;
+            }
+            octal += candidate;
+            read++;
+          }
+
+          bytes.push(parseInt(octal, 8));
+          i += read; // Skip consumed digits
+          continue;
+        }
+
+        const mapped = escapeMap[next];
+        if (mapped !== undefined) {
+          bytes.push(mapped);
+        } else {
+          bytes.push(next.charCodeAt(0));
+        }
+        i++; // Skip the escaped character
+        continue;
+      }
+
+      bytes.push(char.charCodeAt(0));
+    }
+
+    return Buffer.from(bytes).toString('utf8');
+  }
+
+  private extractPathFromLine(line: string | undefined, prefix: string): string | undefined {
+    if (!line?.startsWith(prefix)) {
+      return undefined;
+    }
+
+    return this.decodeGitPath(line.slice(prefix.length));
+  }
+
+  private parseDiffHeaderPaths(
+    headerLine: string
+  ): { oldPath: string | undefined; newPath: string | undefined } | null {
+    if (!headerLine.startsWith('diff --git ')) {
+      return null;
+    }
+
+    const raw = headerLine.slice('diff --git '.length);
+    const segments: string[] = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < raw.length; i++) {
+      const char = raw[i];
+      const prevChar = i > 0 ? raw[i - 1] : null;
+
+      if (char === '"' && prevChar !== '\\') {
+        inQuotes = !inQuotes;
+        current += char;
+        continue;
+      }
+
+      if (char === ' ' && !inQuotes && prevChar !== '\\') {
+        if (current) {
+          segments.push(current);
+          current = '';
+        }
+        continue;
+      }
+
+      current += char;
+    }
+
+    if (current) {
+      segments.push(current);
+    }
+
+    if (segments.length !== 2) {
+      return null;
+    }
+
+    const [rawOldPath, rawNewPath] = segments;
+    return {
+      oldPath: this.decodeGitPath(rawOldPath),
+      newPath: this.decodeGitPath(rawNewPath),
+    };
+  }
+
+  private hasRenameInfo(
+    summary: DiffResultTextFile | DiffResultBinaryFile | DiffResultNameStatusFile
+  ): summary is DiffResultNameStatusFile {
+    return 'from' in summary && typeof summary.from === 'string';
+  }
+
   private parseFileBlock(
     block: string,
-    summary: DiffResultTextFile | DiffResultBinaryFile | null
+    summary: DiffResultTextFile | DiffResultBinaryFile | DiffResultNameStatusFile | null
   ): DiffFile | null {
     const lines = block.split('\n');
     const headerLine = lines[0];
+    const headerPaths = this.parseDiffHeaderPaths(headerLine);
 
-    const pathMatch = headerLine.match(/^diff --git (?:[a-z]\/)?(.+) (?:[a-z]\/)?(.+)$/);
-    if (!pathMatch) return null;
+    const minusLine = lines.find((line) => line.startsWith('--- '));
+    const plusLine = lines.find((line) => line.startsWith('+++ '));
+    const renameFromLine = lines.find((line) => line.startsWith('rename from '));
+    const renameToLine = lines.find((line) => line.startsWith('rename to '));
 
-    const oldPath = pathMatch[1];
-    const newPath = pathMatch[2];
+    const plusPath = this.extractPathFromLine(plusLine, '+++ ');
+    const minusPath = this.extractPathFromLine(minusLine, '--- ');
+    const renameFromPath = this.extractPathFromLine(renameFromLine, 'rename from ');
+    const renameToPath = this.extractPathFromLine(renameToLine, 'rename to ');
+
+    let newPath =
+      this.decodeGitPath(summary?.file) ?? renameToPath ?? plusPath ?? headerPaths?.newPath;
+    let summaryOldPath: string | undefined;
+    if (summary && this.hasRenameInfo(summary)) {
+      summaryOldPath = this.decodeGitPath(summary.from);
+    }
+
+    let oldPath = summaryOldPath ?? renameFromPath ?? minusPath ?? headerPaths?.oldPath ?? newPath;
+
+    if (!newPath) {
+      return null;
+    }
+
     const path = newPath;
 
     let status: DiffFile['status'] = 'modified';
@@ -127,9 +276,6 @@ export class GitDiffParser {
     const deletedFileMode = lines.find((line) => line.startsWith('deleted file mode'));
 
     // Check for /dev/null which indicates added or deleted files
-    const minusLine = lines.find((line) => line.startsWith('--- '));
-    const plusLine = lines.find((line) => line.startsWith('+++ '));
-
     if (newFileMode || minusLine?.includes('/dev/null')) {
       status = 'added';
     } else if (deletedFileMode || plusLine?.includes('/dev/null')) {

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -253,15 +253,17 @@ export class GitDiffParser {
     const minusPath = this.extractPathFromLine(minusLine, '--- ');
     const renameFromPath = this.extractPathFromLine(renameFromLine, 'rename from ');
     const renameToPath = this.extractPathFromLine(renameToLine, 'rename to ');
+    const summaryNewPath = this.decodeGitPath(summary?.file);
 
-    let newPath =
-      this.decodeGitPath(summary?.file) ?? renameToPath ?? plusPath ?? headerPaths?.newPath;
     let summaryOldPath: string | undefined;
     if (summary && this.hasRenameInfo(summary)) {
       summaryOldPath = this.decodeGitPath(summary.from);
     }
 
-    let oldPath = summaryOldPath ?? renameFromPath ?? minusPath ?? headerPaths?.oldPath ?? newPath;
+    const newPath = renameToPath ?? plusPath ?? headerPaths?.newPath ?? summaryNewPath;
+
+    const oldPath =
+      renameFromPath ?? minusPath ?? headerPaths?.oldPath ?? summaryOldPath ?? newPath;
 
     if (!newPath) {
       return null;

--- a/src/server/git-diff.ts
+++ b/src/server/git-diff.ts
@@ -114,7 +114,15 @@ export class GitDiffParser {
 
     const trimmed =
       rawPath.startsWith('"') && rawPath.endsWith('"') ? rawPath.slice(1, -1) : rawPath;
-    const withoutPrefix = trimmed.replace(/^[ab]\//, '');
+
+    const gitPrefixes = ['a/', 'b/', 'c/', 'i/', 'w/'];
+    let withoutPrefix = trimmed;
+    for (const prefix of gitPrefixes) {
+      if (withoutPrefix.startsWith(prefix)) {
+        withoutPrefix = withoutPrefix.slice(prefix.length);
+        break;
+      }
+    }
 
     if (withoutPrefix === '/dev/null') {
       return undefined;


### PR DESCRIPTION

Fixes #83

- Prioritize diff header paths to restore correct `a/` / `b/` prefixed filenames
- Prevent newly added files from being misclassified as renames by gating `oldPath`
- Strip alternate prefixes (`c/`, `w/`, etc.) and trailing tab metadata when decoding diff paths
- Remove stray tabs from filenames so copied comment prompts no longer include leading spaces before `:L1`
- Add regression tests that cover the updated path normalization scenarios


